### PR TITLE
Upcase wind directions

### DIFF
--- a/forecast.el
+++ b/forecast.el
@@ -679,7 +679,7 @@ wind directions."
              (forecast--wind-unit)))
     (insert "      ")
     (mapc (lambda (w)
-            (let ((wb (cdr w)))
+            (let ((wb (upcase (symbol-name (cdr w)))))
               (forecast--insert-format "  %-4s " wb)))
           wind)
     (insert "  Wind bearing\n")


### PR DESCRIPTION
Example: Print "N-SW" instead of "n-sw" in the "Wind Bearing" row