### PR TITLE
Distinctly identify max/min temp in upcoming temp graph

### DIFF
--- a/forecast.el
+++ b/forecast.el
@@ -281,6 +281,16 @@ If not one of these, then `en' is selected."
   :type 'string
   :group 'forecast)
 
+(defcustom forecast-graph-marker-upcoming-max "▀"
+  "A single-character string for the upcoming graph marking the max temperature."
+  :type 'string
+  :group 'forecast)
+
+(defcustom forecast-graph-marker-upcoming-min "▄"
+  "A single-character string for the upcoming graph marking the min temperature."
+  :type 'string
+  :group 'forecast)
+
 (defcustom forecast-old-ui nil
   "If t, use the old text listing for upcoming forecast."
   :type 'boolean
@@ -664,8 +674,16 @@ wind directions."
       (forecast--insert-format "%4d  " i)
       (cl-loop for j upfrom 0 to 7 do
                (insert
-                (cond ((or (= i (nth j hi))
-                           (= i (nth j lo)))
+                (cond ((= i (nth j hi))
+                       (if (oddp i)
+                           (concat "-|-" forecast-graph-marker-upcoming-max "-|-")
+                         (concat " | " forecast-graph-marker-upcoming-max " | ")))
+                      ((= i (nth j lo))
+                       (if (oddp i)
+                           (concat "-|-" forecast-graph-marker-upcoming-min "-|-")
+                         (concat " | " forecast-graph-marker-upcoming-min " | ")))
+                      ((and (< i (nth j hi))
+                            (> i (nth j lo)))
                        (if (oddp i)
                            (concat "-|-" forecast-graph-marker "-|-")
                          (concat " | " forecast-graph-marker " | ")))


### PR DESCRIPTION
Mark the whole temperature range between max and min with
`forecast-graph-marker'.

Add new defcustoms `forecast-graph-marker-upcoming-max' and
`forecast-graph-marker-upcoming-min'.

This is what it looks like now:

![image](https://cloud.githubusercontent.com/assets/3578197/21744789/d6b09b1c-d4ea-11e6-9638-65ac01e4a12f.png)
