### PR TITLE
Fix "Invalid Time Specification" error

### DIFF
--- a/forecast.el
+++ b/forecast.el
@@ -695,7 +695,7 @@ wind directions."
       (newline))
     (forecast--insert-format
      "Day:  %s\n" (mapconcat (lambda (tm)
-                               (format-time-string "%5a  " tm)) time ""))
+                               (format-time-string "%5a  " (seconds-to-time tm))) time ""))
     ;; precipitation
     (insert "      ")
     (mapc (lambda (p)


### PR DESCRIPTION
I'm on Emacs 24.5 and I had to make this change to avoid an "Invalid Time Specification" error.