### PR TITLE
org-variable-pitch.el: fix bug in ordered lists

### DIFF
--- a/org-variable-pitch.el
+++ b/org-variable-pitch.el
@@ -231,8 +231,8 @@ This face is used to keep them in monospace when using
        ,code)
       (,(rx bol (0+ blank)
             (or (: (or (+ digit) letter) (in ".)"))
-                (: (or (in "-+") (1+ blank "\*"))
-                   (opt blank "[" (in "-X ") "]")))
+                (: (or (in "-+") (1+ blank "*"))))
+            (opt blank "[" (in "-X ") "]")
             blank)
        ,code))
     org-variable-pitch-headline-font-lock-keywords


### PR DESCRIPTION
Prior to this patch, the "checkbox" [ ] in a plain list would be
monospaced, as it should be, but not if it was an ordered list
(1., 2., etc.)  Org-mode allows those checkboxes there and they work,
so they should be monospaced as well.  Changed the regexp to do so.
